### PR TITLE
Shortcut to deploy the site

### DIFF
--- a/deploy
+++ b/deploy
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Conveince command to push the static site to the master branch.
+
+git subtree push --prefix public origin master


### PR DESCRIPTION
Instead of having to remember or write down a long command, store it here and run it with `./deploy`.

You will probably have to change the file permissions on it. If you get such an error, run `chmod 755 deploy` and then add and commit and push that change.